### PR TITLE
Set minimum node engine to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "url": "git+https://github.com/furey/mongodb-lens.git"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Hi!

I tried using the MCP locally, but NPX and other commands failed because my version of node was not supported. I use node v20.18.x, but the [docs](https://github.com/furey/mongodb-lens/blob/main/README.md?plain=1#L203) indicate that version 18 is supported. 

Fix: I've updated the package.json to enable users to try the MCP on the version advertised!

Stack Trace:
```
 npx -y mongodb-lens run config:create
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: mongodb-lens@8.0.3
npm error notsup Not compatible with your version of node/npm: mongodb-lens@8.0.3
npm error notsup Required: {"node":">=22.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.18.1"}
npm error A complete log of this run can be found in: /Users/bloo/.npm/_logs/2025-03-31T22_08_38_235Z-debug-0.log
```