### PR TITLE
Update serializeDocument to handle arrays and null values

### DIFF
--- a/mongodb-lens.js
+++ b/mongodb-lens.js
@@ -5146,6 +5146,12 @@ const formatCsvValue = (value) => {
 }
 
 const serializeDocument = (doc) => {
+  if (Array.isArray(doc)) {
+    return doc.map(serializeDocument)
+  }
+  if (doc === null || typeof doc !== 'object') {
+    return doc
+  }
   const result = {}
 
   for (const [key, value] of Object.entries(doc)) {
@@ -5153,6 +5159,8 @@ const serializeDocument = (doc) => {
       result[key] = `ObjectId("${value.toString()}")`
     } else if (value instanceof Date) {
       result[key] = `ISODate("${value.toISOString()}")`
+    } else if (Array.isArray(value)) {
+      result[key] = value.map(serializeDocument)
     } else if (typeof value === 'object' && value !== null) {
       result[key] = serializeDocument(value)
     } else {


### PR DESCRIPTION
This pull request enhances the `serializeDocument` function in `mongodb-lens.js` to improve its handling of arrays and non-object values. The key changes ensure better serialization of nested structures and edge cases. Arrays were being returned as objects with their indexes as keys instead of the actual array.

Enhancements to `serializeDocument`:

* Added logic to handle cases where `doc` is an array, ensuring each element is serialized recursively.
* Improved handling of non-object and `null` values by returning them directly without further processing.
* Enhanced array handling within object properties by serializing each array element recursively.